### PR TITLE
basic database seeding functionality

### DIFF
--- a/.sqlx/query-f8e3598122a2bbdb663039273aae0416c5dd63be2150bf80387552313e9d087a.json
+++ b/.sqlx/query-f8e3598122a2bbdb663039273aae0416c5dd63be2150bf80387552313e9d087a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO user_roles (user_id, role) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "f8e3598122a2bbdb663039273aae0416c5dd63be2150bf80387552313e9d087a"
+}

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -5,6 +5,7 @@ tz = "America/New_York"
 
 [db]
 file = "db.sqlite"
+seed_data = "config/seed_data.json"
 
 [net]
 http_addr = "[::]:8080"

--- a/config/seed_data.toml
+++ b/config/seed_data.toml
@@ -1,0 +1,12 @@
+[[users]]
+email = "test@test.com"
+first_name = "Test"
+last_name = "Testington"
+
+[[user_roles]]
+user_id = 1
+role = "admin"
+
+[[user_roles]]
+user_id = 1
+role = "writer"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,7 @@ pub async fn build(config: Config) -> Result<Router> {
     let state = Arc::new(AppState {
         config: config.clone(),
         templates: utils::tera::templates(&config)?,
-        db: crate::db::init(&config.db.file, config.db.seed_data.as_deref()).await?,
+        db: crate::db::init(&config.db).await?,
         mailer: Emailer::connect(config.email).await?,
     });
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,7 @@ pub async fn build(config: Config) -> Result<Router> {
     let state = Arc::new(AppState {
         config: config.clone(),
         templates: utils::tera::templates(&config)?,
-        db: crate::db::init(&config.db.file).await?,
+        db: crate::db::init(&config.db.file, config.db.seed_data.as_deref()).await?,
         mailer: Emailer::connect(config.email).await?,
     });
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,8 @@
-use anyhow::Result;
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
 use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool};
 use std::path::Path;
+use user::User;
 
 pub type Db = SqlitePool;
 
@@ -12,7 +14,7 @@ pub mod token;
 pub mod user;
 
 /// Create a new db connection pool, initializing and running migrations if necessary.
-pub async fn init(file: &Path) -> Result<Db> {
+pub async fn init(file: &Path, seed_data: Option<&Path>) -> Result<Db> {
     let url = format!("sqlite://{}", file.display());
     if !Sqlite::database_exists(&url).await? {
         Sqlite::create_database(&url).await?;
@@ -21,5 +23,48 @@ pub async fn init(file: &Path) -> Result<Db> {
 
     sqlx::migrate!("./migrations");
 
+    if let Some(seed_data) = seed_data {
+        seed_db(&db, seed_data).await?;
+    }
+
     Ok(db)
+}
+
+#[derive(Deserialize)]
+struct SeedData {
+    users: Vec<user::UpdateUser>,
+    user_roles: Vec<user::UserRole>,
+}
+
+impl SeedData {
+    pub async fn load(file: &Path) -> Result<Self> {
+        let contents = tokio::fs::read_to_string(file).await?;
+        toml::from_str(&contents).with_context(|| format!("loading config={file:#?}"))
+    }
+}
+
+async fn seed_db(db: &Db, seed_data_path: &Path) -> Result<()> {
+    let seed_data = SeedData::load(seed_data_path).await?;
+
+    for user in seed_data.users {
+        if User::lookup_by_email(db, &user.email).await?.is_none() {
+            User::create(db, &user).await?;
+        }
+    }
+
+    for user_role in seed_data.user_roles {
+        if sqlx::query!(
+            "SELECT * FROM user_roles WHERE user_id = ? AND role = ?",
+            user_role.user_id,
+            user_role.role
+        )
+        .fetch_optional(db)
+        .await?
+        .is_none()
+        {
+            User::add_role(db, user_role.user_id, &user_role.role).await?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,6 +4,8 @@ use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool};
 use std::path::Path;
 use user::User;
 
+use crate::utils::config::DbConfig;
+
 pub type Db = SqlitePool;
 
 pub mod email;
@@ -14,8 +16,8 @@ pub mod token;
 pub mod user;
 
 /// Create a new db connection pool, initializing and running migrations if necessary.
-pub async fn init(file: &Path, seed_data: Option<&Path>) -> Result<Db> {
-    let url = format!("sqlite://{}", file.display());
+pub async fn init(db_config: &DbConfig) -> Result<Db> {
+    let url = format!("sqlite://{}", db_config.file.display());
     if !Sqlite::database_exists(&url).await? {
         Sqlite::create_database(&url).await?;
     }
@@ -23,7 +25,7 @@ pub async fn init(file: &Path, seed_data: Option<&Path>) -> Result<Db> {
 
     sqlx::migrate!("./migrations");
 
-    if let Some(seed_data) = seed_data {
+    if let Some(seed_data) = &db_config.seed_data {
         seed_db(&db, seed_data).await?;
     }
 

--- a/src/db/user.rs
+++ b/src/db/user.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
 
 use super::Db;
 
-#[derive(Clone, Debug, sqlx::FromRow, serde::Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct User {
     pub id: i64,
     pub first_name: String,
@@ -13,6 +14,13 @@ pub struct User {
 }
 
 impl User {}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UserRole {
+    pub user_id: i64,
+    pub role: String,
+    pub created_at: NaiveDateTime,
+}
 
 #[derive(Debug, serde::Deserialize)]
 pub struct UpdateUser {
@@ -40,6 +48,13 @@ impl User {
         .execute(db)
         .await?;
         Ok(row.last_insert_rowid())
+    }
+
+    pub async fn add_role(db: &Db, user_id: i64, role: &str) -> Result<()> {
+        sqlx::query!(r#"INSERT INTO user_roles (user_id, role) VALUES (?, ?)"#, user_id, role)
+            .execute(db)
+            .await?;
+        Ok(())
     }
 
     /// Lookup a user by email address, if one exists.

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -40,6 +40,7 @@ pub struct AppConfig {
 pub struct DbConfig {
     /// Path to sqlite3 database file.
     pub file: PathBuf,
+    pub seed_data: Option<PathBuf>,
 }
 
 /// Networking configuration.


### PR DESCRIPTION
Some developer convenience to define an initial set of data to seed the local dev database to e.g. avoid needing to register a new user when resetting the database. Currently only seeding users and user_roles tables but can be easily extended in the future.