### PR TITLE
more detailed logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 axum = { version = "0.8", default-features = false, features = ["query", "form"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
-tower-http = { version = "0.6", features = ["fs", "trace"] }
+tower-http = { version = "0.6", features = ["fs", "request-id", "trace", "util"] }
 tera = "1"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "chrono"] }
 lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "pool", "smtp-transport", "tokio1", "tokio1-rustls-tls", "serde"] }
@@ -25,6 +25,8 @@ toml = "0.8"
 rand = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.10", features = ["serde"] }
+uuid = { version = "1.16.0", features = ["v7"] }
+tower = "0.5.2"
 
 # Add a little optimization to debug builds
 [profile.dev]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,23 @@ mod utils;
 use axum::{handler::HandlerWithoutStateExt, response::Redirect};
 use axum_server::tls_rustls::RustlsConfig;
 use futures::StreamExt;
+use tracing::{level_filters::LevelFilter, Level};
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 use utils::config::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().init();
+    let log_filter = tracing_subscriber::filter::Targets::default()
+        .with_target("h2", LevelFilter::OFF)
+        .with_default(Level::DEBUG);
+
+    tracing_subscriber::fmt()
+        .with_target(true)
+        .with_line_number(true)
+        .with_max_level(Level::DEBUG)
+        .finish()
+        .with(log_filter)
+        .try_init()?;
 
     // Load the server config
     let file = std::env::args().nth(1).context("usage: lsd <config.toml>")?;

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -1,30 +1,33 @@
-use std::time::Duration;
-
-use axum::{http::Request, response::Response};
-use tower_http::trace::TraceLayer;
-use tracing::Span;
+use axum::http::Request;
+use tower::ServiceBuilder;
+use tower_http::request_id::{MakeRequestId, RequestId};
+use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use tower_http::ServiceBuilderExt as _;
+use uuid::Uuid;
 
 use crate::utils::types::AppRouter;
+
+#[derive(Clone, Copy)]
+pub struct MakeRequestUuidV7;
+impl MakeRequestId for MakeRequestUuidV7 {
+    fn make_request_id<B>(&mut self, _request: &Request<B>) -> Option<RequestId> {
+        // Use UUIDv7 so that request ID can be sorted by time
+        let request_id = Uuid::now_v7();
+        Some(RequestId::new(request_id.to_string().parse().unwrap()))
+    }
+}
 
 /// Register debug tracing middleware.
 pub fn register(router: AppRouter) -> AppRouter {
     // Add a middleware that logs all incoming requests and responses, including latency and status.
     router.layer(
-        TraceLayer::new_for_http()
-            // Start a `tracing::span` for each request.
-            .make_span_with(|req: &Request<_>| {
-                // Fields populated later must be initialized as `tracing::field::Empty`.
-                tracing::info_span!(
-                    "request",
-                    method = ?req.method(),
-                    path = req.uri().path(),
-                    status = tracing::field::Empty
-                )
-            })
-            // Add some extra fields once the response is generated.
-            .on_response(|res: &Response, latency: Duration, span: &Span| {
-                span.record("status", res.status().as_u16());
-                tracing::info!("handled in {latency:?}");
-            }),
+        ServiceBuilder::new()
+            .set_x_request_id(MakeRequestUuidV7)
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(DefaultMakeSpan::new().include_headers(true))
+                    .on_response(DefaultOnResponse::new().include_headers(true)),
+            )
+            .propagate_x_request_id(),
     )
 }


### PR DESCRIPTION
My experience live debugging web services tells me that it's better to have thee details before you need them.

Old log format:

```log
2025-04-02T18:44:48.128651Z  INFO request{method=GET path="/" status=200}: lsd::utils::tracing: handled in 2.342791ms
```

```log
2025-04-02T18:43:36.391236Z DEBUG request{method=GET uri=https://localhost:4433/ version=HTTP/2.0 headers={"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:136.0) Gecko/20100101 Firefox/136.0", "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "accept-language": "en-US,en;q=0.5", "accept-encoding": "gzip, deflate, br, zstd", "dnt": "1", "sec-gpc": "1", "cookie": "session=d7c32f1d975ec382", "upgrade-insecure-requests": "1", "sec-fetch-dest": "document", "sec-fetch-mode": "navigate", "sec-fetch-site": "none", "sec-fetch-user": "?1", "priority": "u=0, i", "te": "trailers", "x-request-id": "0195f7d0-e147-7b53-9e1d-f3e022cff803"}}: tower_http::trace::on_request: 80: started processing request
2025-04-02T18:43:36.392776Z DEBUG request{method=GET uri=https://localhost:4433/ version=HTTP/2.0 headers={"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:136.0) Gecko/20100101 Firefox/136.0", "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "accept-language": "en-US,en;q=0.5", "accept-encoding": "gzip, deflate, br, zstd", "dnt": "1", "sec-gpc": "1", "cookie": "session=d7c32f1d975ec382", "upgrade-insecure-requests": "1", "sec-fetch-dest": "document", "sec-fetch-mode": "navigate", "sec-fetch-site": "none", "sec-fetch-user": "?1", "priority": "u=0, i", "te": "trailers", "x-request-id": "0195f7d0-e147-7b53-9e1d-f3e022cff803"}}: sqlx::query: 143: summary="SELECT u.* FROM session_tokens …" db.statement="\n\nSELECT u.*\n               FROM session_tokens t\n               JOIN users u on u.id = t.user_id\n               WHERE token = ?\n" rows_affected=0 rows_returned=1 elapsed=1.269917ms elapsed_secs=0.001269917
2025-04-02T18:43:36.393310Z DEBUG request{method=GET uri=https://localhost:4433/ version=HTTP/2.0 headers={"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:136.0) Gecko/20100101 Firefox/136.0", "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "accept-language": "en-US,en;q=0.5", "accept-encoding": "gzip, deflate, br, zstd", "dnt": "1", "sec-gpc": "1", "cookie": "session=d7c32f1d975ec382", "upgrade-insecure-requests": "1", "sec-fetch-dest": "document", "sec-fetch-mode": "navigate", "sec-fetch-site": "none", "sec-fetch-user": "?1", "priority": "u=0, i", "te": "trailers", "x-request-id": "0195f7d0-e147-7b53-9e1d-f3e022cff803"}}: tower_http::trace::on_response: 114: finished processing request latency=2 ms status=200 response_headers={"content-type": "text/html; charset=utf-8", "x-request-id": "0195f7d0-e147-7b53-9e1d-f3e022cff803"}
```

Obviously this is significantly wordier but it should be trivial to correlate logs to a specific request using the new request-id header.

Having a method to search these logs retroactively would be nice too. Currently they are sent straight to stdout but they could be redirected to a file with https://crates.io/crates/tracing-appender and searched with ripgrep.