### PR TITLE
doc: Update README with sqlx instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Coming to you live.
 ## Setup
 
 Install a rust toolchain with [rustup.rs](https://rustup.rs):
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 cargo --version
@@ -12,25 +13,31 @@ rustc --version
 ```
 
 Clone the repo:
+
 ```sh
 git clone https://github.com/foltik/lsd
 cd lsd
 ```
 
+Create a .env file with `DATABASE_URL=sqlite://db.sqlite`
+
 Initialize dev database:
+
 ```sh
+cargo install sqlx-cli --no-default-features --features sqlite
 cargo sqlx database create
+cargo sql migrate run
 ```
 
-Create a .env file with `DATABASE_URL=sqlite://lsd.sqlite`
-
 To automatically recompile and rerun when you make changes, use `cargo-watch`:
+
 ```sh
 cargo install cargo-watch
 cargo watch -x 'run config/dev.toml'
 ```
 
 Use [mailtutan](https://github.com/mailtutan/mailtutan) for local testing of email functionality:
+
 ```sh
 cargo install mailtutan
 mailtutan
@@ -38,5 +45,5 @@ mailtutan
 
 ## Workflow
 
-* Make commits in a separate branch, and open a PR against `main`
-* When new commits land in `main`, a github action will automatically deploy the app to https://beta.lightandsound.design
+- Make commits in a separate branch, and open a PR against `main`
+- When new commits land in `main`, a github action will automatically deploy the app to https://beta.lightandsound.design

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Initialize dev database:
 
 ```sh
 cargo install sqlx-cli --no-default-features --features sqlite
-cargo sqlx database create
 cargo sqlx database setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Initialize dev database:
 ```sh
 cargo install sqlx-cli --no-default-features --features sqlite
 cargo sqlx database create
-cargo sql migrate run
+cargo sqlx database setup
 ```
 
 To automatically recompile and rerun when you make changes, use `cargo-watch`:


### PR DESCRIPTION
The current README doesn’t have instructions on installing `sqlx-cli` which is required to create the database and run migrations. I also changed the `DATABASE_URL` in `.env` to reflect `config/dev.toml`.