### PR TITLE
Fix for error in cross test when installing arch-linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,5 +66,5 @@ jobs:
           targets: aarch64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
       - name: install gcc-aarch64-linux-gnu
-        run: sudo apt install -y gcc-aarch64-linux-gnu
+        run: sudo apt update && sudo apt install -y gcc-aarch64-linux-gnu
       - run: cargo build --target aarch64-unknown-linux-gnu


### PR DESCRIPTION
Was seeing this error pop up on recent `cross` tests in test pipelines.

Found fix in this discusssion: 
https://github.com/actions/runner/issues/3720

Workflows with same error:
https://github.com/foltik/lsd/actions/runs/14377057964/job/40311863555#step:5:68
https://github.com/foltik/lsd/actions/runs/14373431950/job/40300611303#step:5:68
