### PR TITLE
seed db with a test cookie

### DIFF
--- a/config/seed_data.toml
+++ b/config/seed_data.toml
@@ -3,12 +3,17 @@ email = "test@test.com"
 first_name = "Test"
 last_name = "Testington"
 
+# Can add manually to cookies store in browser to persist sessions between database resets
+[[session_tokens]]
+user_id = 1
+token = "91acde7529be7cf7"
+
 [[user_roles]]
 user_id = 1
 role = "admin"
-created_at="2025-04-04T16:03:35"
+created_at = "2025-04-04T16:03:35"
 
 [[user_roles]]
 user_id = 1
 role = "writer"
-created_at="2025-04-04T16:03:35"
+created_at = "2025-04-04T16:03:35"


### PR DESCRIPTION
I've been doing a lot of `sqlx database reset`s recently while testing migrations and it's annoying having to re-log in every time. This seeds the DB with a test cookie so that a dev login session can persist across database resets. The cookie can be manually added to the browser's cookie store via dev tools.